### PR TITLE
convert Type I and Type II arrays to single type array

### DIFF
--- a/pokemonDataGraber.js
+++ b/pokemonDataGraber.js
@@ -9,6 +9,7 @@ var pokemonDataGraber = {
             var currentPokemon = {};
             var $ = cheerio.load(body);
             var $table = $('#omc-full-article table');
+            var types = [];
 
             $table.find('strong').each(function () {
                 var key = $(this).text();
@@ -16,6 +17,12 @@ var pokemonDataGraber = {
                 switch (key) {
                     case 'Type I':
                     case 'Type II':
+                      $td.find('.icon-type').each(function () {
+                        types.push($(this).text().trim());
+                      })
+                      key = "Types";
+                      value = types;
+                      break;
                     case 'Weaknesses':
                         var value = [];
                         $td.find('.icon-type').each(function () {


### PR DESCRIPTION
I was doing extra work sanitizing this on my end to put all types into a single array, so this will update this: `"Type I":["Grass"],"Type II":["Poison"]`

to this: `"Types":["Grass","Poison"]`
