### PR TITLE
Fixed About text, added male/female icons to Nidoran, using condensed pokedex

### DIFF
--- a/src/fevgamesTableParser.js
+++ b/src/fevgamesTableParser.js
@@ -2,6 +2,10 @@ var AttackDataGraber = require('./attackDataGraber');
 class FevgamesTableParser {
     constructor() {
         this.attackDataGraber = new AttackDataGraber();
+        this.nameSuffixes = {
+            "029": " ♀",
+            "032": " ♂"
+        };
     }
     getData($, $table) {
         this.$ = $;
@@ -76,6 +80,11 @@ class FevgamesTableParser {
                 case 'Name':
                     value = $td.text().split(')')[1].trim();
                     this.currentPokemon.Number = $td.text().substring(2, 5);
+
+                    if (this.nameSuffixes.hasOwnProperty(this.currentPokemon.Number)) {
+                        value += this.nameSuffixes[this.currentPokemon.Number];
+                    }
+
                     this.currentPokemon[key] = value;
                     this.parse(callback);
                     break;
@@ -120,6 +129,11 @@ class FevgamesTableParser {
                         value.push(this.$(element).text().trim());
                     });
                     this.currentPokemon[key] = value;
+                    this.parse(callback);
+                    break;
+                case 'About':
+                    $td.find('button, script').remove();
+                    this.currentPokemon[key] = $td.text().trim();
                     this.parse(callback);
                     break;
                 default:

--- a/src/pokedexUrlGraber.js
+++ b/src/pokedexUrlGraber.js
@@ -6,7 +6,7 @@ class PokedexUrlGraber {
         this.logger = logger;
         return new Promise((resolve, reject) => {
             request({
-                uri: 'https://fevgames.net/pokedex'
+                uri: 'https://fevgames.net/pokemon-go/pokedex-table/'
             }, (error, response, body) => {
                 if (error) {
                     reject(err); return;
@@ -15,7 +15,7 @@ class PokedexUrlGraber {
                 let urls = [];
                 let $ = cheerio.load(body);
 
-                $(".pokedex-item").each((index, element) => {
+                $(".pokedexTable > tbody > tr > td:nth-of-type(2) > a").each((index, element) => {
                     var url = $(element).attr('href');
                     this.logger('| Found ' + url);
                     urls.push(url);


### PR DESCRIPTION
Hey there,

first: Thanks for this nice script! I've done a few changes to hit and hope it's helpful to others:
- Fixed About: The About field on fevgames has a button and script-tag by now. I've added some logic to remove this and only have the about text (again)
- Nidoran were missing the male and female icons, to by just looking at the name you could not see which it is. I made it more generic to have name suffixes. Maybe it comes in handy in the future again
- I saw that you were using the pokesdex page with all the images. There is a condensed version which should be less traffic for fevgames and this script

Greetings,

Andy!